### PR TITLE
improve camera setup

### DIFF
--- a/sparse/usr/bin/cameras_setup.sh
+++ b/sparse/usr/bin/cameras_setup.sh
@@ -1,3 +1,25 @@
 #!/bin/sh
-media-ctl -d /dev/media0 --set-v4l2 '"ov5640 3-004c":0[fmt:YUYV8_2X8/1280x720]'
-media-ctl -d /dev/media0 --set-v4l2 '"gc2145 3-003c":0[fmt:YUYV8_2X8/1280x720]'
+
+# UBports enables camera like this:
+# https://gitlab.com/ubports/porting/community-ports/pinephone/-/merge_requests/5/diffs#f40b4251139496d6f8c502a834435af25ed50118
+# media-ctl -d /dev/media1 --set-v4l2 '"ov5640 3-004c":0[fmt:UYVY8_2X8/1920x1080@1/15]'
+
+# this part is taken from OpenMandriva
+# https://gitlab.com/tui/tui/-/blob/master/cam/camera-setup
+
+case "a$1" in
+    a | arear)
+        media-ctl -d /dev/media1 --links '"gc2145 3-003c":0->"sun6i-csi":0[0]'
+        media-ctl -d /dev/media1 --links '"ov5640 3-004c":0->"sun6i-csi":0[1]'
+        media-ctl -d /dev/media1 --set-v4l2 '"ov5640 3-004c":0[fmt:UYVY8_2X8/1280x720]'
+    ;;
+    afront)
+        media-ctl -d /dev/media1 --links '"ov5640 3-004c":0->"sun6i-csi":0[0]'
+        media-ctl -d /dev/media1 --links '"gc2145 3-003c":0->"sun6i-csi":0[1]'
+        media-ctl -d /dev/media1 --set-v4l2 '"gc2145 3-003c":0[fmt:UYVY8_2X8/1280x720]'
+    ;;
+esac
+
+# Take a photo: e.g.
+#   ffmpeg -s 1280x720 -f video4linux2 -i /dev/video2 -vframes 1 /home/manjaro/Pictures/photo.jpg
+#   ffmpeg -s 1280x720 -f video4linux2 -i /dev/video2 -vframes 5 /home/manjaro/Pictures/photo%d.jpg


### PR DESCRIPTION
I have taken configuration from https://gitlab.com/tui/tui/-/blob/master/cam/camera-setup (basically OpenMandriva) and https://gitlab.com/ubports/porting/community-ports/pinephone/-/merge_requests/5/diffs#f40b4251139496d6f8c502a834435af25ed50118 UBports. 

It seems both of them are using /dev/media1 instead of /dev/media0. Additionally, below added ffmpeg command really takes some pictures.

Next, I was checking glacier-camera which produces following output
```
Unable to query the parameter info: QCameraImageProcessingControl::WhiteBalancePreset : "Inappropriate ioctl for device"
Unable to query the parameter info: QCameraImageProcessingControl::ColorTemperature : "Inappropriate ioctl for device"
Unable to query the parameter info: QCameraImageProcessingControl::ContrastAdjustment : "Inappropriate ioctl for device"
Unable to query the parameter info: QCameraImageProcessingControl::SaturationAdjustment : "Inappropriate ioctl for device"
Unable to query the parameter info: QCameraImageProcessingControl::BrightnessAdjustment : "Inappropriate ioctl for device"
Unable to query the parameter info: QCameraImageProcessingControl::SharpeningAdjustment : "Inappropriate ioctl for device"
CameraBin error: "Device '/dev/video2' does not support 2:0:0:0 colorimetry"
```